### PR TITLE
feat: 모듈 및 게시판 설정 추가 및 설정 적용

### DIFF
--- a/conf/module.xml
+++ b/conf/module.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
-    <!--
-    모듈의 기본 클래스를 지정합니다.
-    여기에 지정된 클래스(`name` 속성)는 `\ModuleObject` 클래스를 상속해야 합니다.
-    -->
     <classes>
         <class type="default" name="Src\ModuleBase" />
         <class type="install" name="Src\ModuleBase" />
@@ -12,6 +8,19 @@
     <actions>
         <action name="procDa_reactionReact"
             class="Src\Controllers\RequestHandler" />
+
+
+        <!-- ADMIN ========================================================= -->
+        <!-- index -->
+        <action name="dispDa_reactionAdminConfig"
+            class="Src\Controllers\AdminRequestHandler"
+            admin-index="true"
+            menu-name="daReactionConfig" />
+        <!-- 모듈 설정 저장 -->
+        <action name="procDa_reactionAdminSaveConfig"
+            class="Src\Controllers\AdminRequestHandler" />
+        <action name="procDa_reactionAdminSaveModuleConfig"
+            class="Src\Controllers\AdminRequestHandler" />
     </actions>
 
     <!-- 이벤트 핸들러 등록 -->
@@ -19,9 +28,15 @@
         <eventHandler after="moduleHandler.proc"
             class="Src\EventHandler"
             method="ListenerModuleHandlerProcAfter" />
+        <eventHandler before="module.dispAdditionSetup"
+            class="Src\EventHandler"
+            method="ListenerModuleDispAdditionSetup" />
     </eventHandlers>
 
     <!-- 관리페이지용 메뉴 -->
     <menus>
+        <menu name="daReactionConfig" type="all">
+            <title xml:lang="ko">daReactionConfig</title>
+        </menu>
     </menus>
 </module>

--- a/public/assets/da_reaction.js
+++ b/public/assets/da_reaction.js
@@ -24,6 +24,7 @@
  * @property {'prepend'|'append'} placement 리액션 이모티콘을 삽입할 위치
  *
  * @typedef {Object} ReactionOptions
+ * @property {boolean} reactable 리액션 가능 여부
  * @property {number} reactionLimit 리액션 회숫 제한
  */
 
@@ -34,6 +35,7 @@ document.addEventListener('alpine:init', function () {
   Alpine.store('reactionData', {
     /** @type {ReactionOptions} */
     options: {
+      reactable: true,
       reactionLimit: 20,
     },
     /** @type {boolean} */
@@ -120,7 +122,7 @@ document.addEventListener('alpine:init', function () {
       this.targetId = target;
       this.parentId = parent;
 
-      Object.assign(this.options, options);
+      Object.assign(this.options, this.$store.reactionData.options, options);
 
       Alpine.effect(() => {
         this.reactions = this.$store.reactionData?.reactions[this.targetId] ?? {};
@@ -183,7 +185,7 @@ document.addEventListener('alpine:init', function () {
 
     // TODO 템플릿 분리
     const template = `
-        <div x-show="options.button" x-bind="daReactionButton" class="da-reaction__button" :class="{ 'da-reaction__button--end': options.button === 'end' }" title="리액션 남기기"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-emoji-smile" viewBox="0 0 16 16"><path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14m0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16"/> <path d="M4.285 9.567a.5.5 0 0 1 .683.183A3.5 3.5 0 0 0 8 11.5a3.5 3.5 0 0 0 3.032-1.75.5.5 0 1 1 .866.5A4.5 4.5 0 0 1 8 12.5a4.5 4.5 0 0 1-3.898-2.25.5.5 0 0 1 .183-.683M7 6.5C7 7.328 6.552 8 6 8s-1-.672-1-1.5S5.448 5 6 5s1 .672 1 1.5m4 0c0 .828-.448 1.5-1 1.5s-1-.672-1-1.5S9.448 5 10 5s1 .672 1 1.5"/></svg></div>
+        <div x-show="options.button && options.reactable" x-bind="daReactionButton" class="da-reaction__button" :class="{ 'da-reaction__button--end': options.button === 'end' }" title="리액션 남기기"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-emoji-smile" viewBox="0 0 16 16"><path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14m0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16"/> <path d="M4.285 9.567a.5.5 0 0 1 .683.183A3.5 3.5 0 0 0 8 11.5a3.5 3.5 0 0 0 3.032-1.75.5.5 0 1 1 .866.5A4.5 4.5 0 0 1 8 12.5a4.5 4.5 0 0 1-3.898-2.25.5.5 0 0 1 .183-.683M7 6.5C7 7.328 6.552 8 6 8s-1-.672-1-1.5S5.448 5 6 5s1 .672 1 1.5m4 0c0 .828-.448 1.5-1 1.5s-1-.672-1-1.5S9.448 5 10 5s1 .672 1 1.5"/></svg></div>
         <template x-for="reaction in getReactions()" :key="reaction.reaction">
           <template x-if="reaction.count >= 1 && reaction.emoticon.renderType">
             <span role="button" tabindex="0" class="da-reaction__badge" :class="{'da-reaction__badge--choose': reaction.choose }" @click="toggle(reaction.reaction)" @keyup.enter="toggle(reaction.reaction)">

--- a/src/ModuleBase.php
+++ b/src/ModuleBase.php
@@ -3,9 +3,8 @@ declare(strict_types=1);
 
 namespace Rhymix\Modules\Da_reaction\Src;
 
-use ModuleHandler;
-use Rhymix\Modules\Da_reaction\Src\Models\ReactionContainer;
-use Rhymix\Modules\Da_reaction\Src\Models\ReactionModel;
+use Rhymix\Modules\Da_reaction\Src\Models\ReactionConfig;
+use Rhymix\Modules\Da_reaction\Src\Models\ReactionPartConfig;
 
 /**
  * 모듈의 액션을 처리하는 클래스
@@ -24,6 +23,14 @@ class ModuleBase extends \ModuleObject
     public static string $tableReaction = 'da_reaction';
     public static string $tableReactionChoose = 'da_reaction_choose';
 
+    /** @var ReactionConfig */
+    protected static ReactionConfig $config;
+    /** @var array<int,ReactionPartConfig> */
+    protected static array $partConfigInstances = [];
+
+    /**
+     * @return array<string,mixed>
+     */
     public static function loadCustomConfig(): array
     {
         $customData = [];
@@ -42,5 +49,23 @@ class ModuleBase extends \ModuleObject
         }
 
         return $customData;
+    }
+
+    public static function getConfig(): ReactionConfig
+    {
+        if (!isset(static::$config)) {
+            static::$config = new ReactionConfig();
+        }
+
+        return static::$config;
+    }
+
+    public static function getPartConfig(int $moduleSrl): ReactionPartConfig
+    {
+        if (!isset(static::$partConfigInstances[$moduleSrl])) {
+            static::$partConfigInstances[$moduleSrl] = new ReactionPartConfig(static::getConfig(), $moduleSrl);
+        }
+
+        return static::$partConfigInstances[$moduleSrl];
     }
 }

--- a/src/ReactionHelper.php
+++ b/src/ReactionHelper.php
@@ -112,4 +112,27 @@ class ReactionHelper
 
         return $result;
     }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public static function parseTargetId(string $target): array
+    {
+        $result = [];
+
+        $parts = explode(':', $target);
+        if ($parts[0] === 'document' && count($parts) === 3) {
+            $result['type'] = $parts[0];
+            $result['module_srl'] = intval($parts[1]);
+            $result['document_srl'] = intval($parts[2]);
+        } else if ($parts[0] === 'comment' && count($parts) === 3) {
+            $result['type'] = $parts[0];
+            $result['module_srl'] = intval($parts[1]);
+            $result['comment_srl'] = intval($parts[2]);
+        } else {
+            $result = $parts;
+        }
+
+        return $result;
+    }
 }

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Rhymix\Modules\Da_reaction\Src\Controllers;
 
+use PDO;
+use Rhymix\Framework\Exception;
 use Rhymix\Modules\Da_reaction\Src\ModuleBase;
 
 class AdminController extends ModuleBase

--- a/src/controllers/AdminRequestHandler.php
+++ b/src/controllers/AdminRequestHandler.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+namespace Rhymix\Modules\Da_reaction\Src\Controllers;
+
+use Context;
+use MemberModel;
+use Rhymix\Modules\Da_reaction\Src\ModuleBase;
+
+class AdminRequestHandler extends ModuleBase
+{
+    public function dispDa_reactionAdminConfig(): void
+    {
+
+        // 현재 설정 상태 불러오기
+        $config = self::getConfig();
+
+        Context::set('daReactionConfig', $config);
+
+        $group_list = MemberModel::getGroups();
+        foreach ($group_list ?: [] as $group) {
+            $group->title = Context::replaceUserLang($group->title, true);
+        }
+        Context::set('group_list', $group_list);
+
+        $this->setTemplatePath("{$this->module_path}views/admin/");
+        $this->setTemplateFile('config');
+    }
+
+    public function procDa_reactionAdminSaveConfig(): void
+    {
+        // 현재 설정 상태 불러오기
+        $config = self::getConfig();
+
+        $vars = (array) Context::getRequestVars();
+
+        $config->setVars($vars);
+
+        // 변경된 설정을 저장
+        $result = $config->save();
+
+        $this->setMessage('success_saved');
+        $this->setRedirectUrl(getNotEncodedUrl('', 'module', 'admin', 'act', 'dispDa_reactionAdminConfig'));
+    }
+
+    public function procDa_reactionAdminSaveModuleConfig(): void
+    {
+        $moduleSrl = intval(Context::get('target_module_srl') ?? 0);
+
+        // 현재 설정 상태 불러오기
+        $config = ModuleBase::getPartConfig($moduleSrl);
+
+
+        $vars = Context::getRequestVars();
+        $vars->ignore_part_config ??= false;
+
+        dp($vars);
+        $config->setVars((array) $vars);
+
+        // 변경된 설정을 저장
+        $config->save();
+
+        $this->setMessage('success_saved');
+        $this->setRedirectUrl(Context::get('success_return_url'));
+    }
+}

--- a/src/controllers/ReactionController.php
+++ b/src/controllers/ReactionController.php
@@ -3,8 +3,13 @@ declare(strict_types=1);
 
 namespace Rhymix\Modules\Da_reaction\Src\Controllers;
 
+use CommentModel;
+use DocumentModel;
+use Rhymix\Framework\Exception;
 use Rhymix\Framework\Exceptions\MustLogin;
 use Rhymix\Framework\Helpers\SessionHelper;
+use Rhymix\Modules\Da_reaction\Src\Exceptions\CannotReactToOwnTargetException;
+use Rhymix\Modules\Da_reaction\Src\Models\ReactionConfig;
 use Rhymix\Modules\Da_reaction\Src\Models\ReactionModel;
 use Rhymix\Modules\Da_reaction\Src\ModuleBase;
 use Rhymix\Modules\Da_reaction\Src\ReactionHelper;
@@ -16,7 +21,7 @@ class ReactionController extends ModuleBase
      *
      * @throws MustLogin
      */
-    public static function react(SessionHelper $member, string $reactionMode, string $reaction, string $targetId, string $parentId): bool
+    public static function react(ReactionConfig $config, SessionHelper $member, string $reactionMode, string $reaction, string $targetId, string $parentId): bool
     {
         if (!$member->isMember()) {
             throw new MustLogin();
@@ -28,12 +33,35 @@ class ReactionController extends ModuleBase
             ReactionHelper::validateTargetId($parentId);
         }
 
+        $targetInfo = ReactionHelper::parseTargetId($targetId);
+
+        try {
+            $config->reactable($member);
+        } catch (Exception $e) {
+            throw new Exception("리액션 할 수 없습니다. ({$e->getmessage()})", 0, $e);
+        }
+
         // 리액션 제한 확인
-        $reactable = ReactionModel::reactable($targetId, $reaction, $member);
+        $reactable = ReactionModel::reactable($config, $member, $targetId, $reaction);
 
         if ($reactionMode === 'toggle' && $reactable ^ ModuleBase::REACTABLE_ADD) {
             return ReactionModel::revokeReaction($member->member_srl, $reaction, $targetId);
+
         } else if ($reactable & ModuleBase::REACTABLE_ADD) {
+            if (!$member->isAdmin() && !$config->reaction_self) {
+                if ($targetInfo['type'] === 'document') {
+                    $documentItem = DocumentModel::getDocument($targetInfo['document_srl']);
+                    if ($documentItem->get('member_srl') === $member->member_srl) {
+                        throw new CannotReactToOwnTargetException('자신의 글에는 리액션할 수 없습니다.');
+                    }
+                } else if ($targetInfo['type'] === 'comment') {
+                    $commentItem = CommentModel::getComment($targetInfo['comment_srl']);
+                    if ($commentItem->get('member_srl') === $member->member_srl) {
+                        throw new CannotReactToOwnTargetException('자신의 댓글에는 리액션할 수 없습니다.');
+                    }
+                }
+            }
+
             return ReactionModel::addReaction($member->member_srl, $reaction, $targetId, $parentId);
         }
 

--- a/src/controllers/RequestHandler.php
+++ b/src/controllers/RequestHandler.php
@@ -8,6 +8,7 @@ use Rhymix\Framework\Exception;
 use Rhymix\Framework\Session;
 use Rhymix\Modules\Da_reaction\Src\Models\ReactionModel;
 use Rhymix\Modules\Da_reaction\Src\ModuleBase;
+use Rhymix\Modules\Da_reaction\Src\ReactionHelper;
 
 /**
  * 라이믹스 요청 핸들러
@@ -24,10 +25,14 @@ class RequestHandler extends ModuleBase
         $targetId = Context::get('targetId');
         $parentId = Context::get('parentId');
 
+        $targetInfo = ReactionHelper::parseTargetId($targetId);
+        $moduleSrl = $targetInfo['module_srl'];
+
         $member = Session::getMemberInfo();
+        $config = $moduleSrl ? static::getPartConfig($moduleSrl) : static::getConfig();
 
         try {
-            ReactionController::react($member, $reactionMode, $reaction, $targetId, $parentId);
+            ReactionController::react($config, $member, $reactionMode, $reaction, $targetId, $parentId);
         } catch (Exception $e) {
             $this->setError(-1);
             $this->setMessage($e->getMessage(), 'error');

--- a/src/exceptions/CannotReactToOwnTargetException.php
+++ b/src/exceptions/CannotReactToOwnTargetException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rhymix\Modules\Da_reaction\Src\Exceptions;
+
+class CannotReactToOwnTargetException extends \Rhymix\Framework\Exception
+{
+    public function __construct(string $message = "", int $code = 0, \Throwable $previous = null)
+    {
+        $message = $message ?: '리액션 할 수 없습니다.';
+
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/models/ReactionConfig.php
+++ b/src/models/ReactionConfig.php
@@ -1,0 +1,212 @@
+<?php
+declare(strict_types=1);
+
+namespace Rhymix\Modules\Da_reaction\Src\Models;
+
+use ModuleController;
+use ModuleModel;
+use Rhymix\Framework\Exceptions\MustLogin;
+use Rhymix\Framework\Exceptions\NotPermitted;
+use Rhymix\Framework\Helpers\SessionHelper;
+
+/**
+ * 리액션 모듈의 설정
+ *
+ * @property bool $enable
+ * @property int $reaction_limit 리액션 제한 수
+ * @property bool $reaction_self 자신의 글, 댓글에 리액션 제한
+ * @property string $reaction_allows
+ * @property string $document_insert_position 문서 리액션 버튼 추가 위치
+ * @property string $comment_insert_position 댓글 리액션 버튼 추가 위치
+ */
+class ReactionConfig
+{
+    protected string $configKey = 'da_reaction';
+
+    /**
+     * @var object
+     */
+    protected object $config;
+
+    /**
+     * @var array{
+     *     enable: bool,
+     *     ignore_part_config: bool,
+     *     reaction_limit: int,
+     *     reaction_self: bool,
+     *     reaction_allows: string,
+     *     document_insert_position: string,
+     *     comment_insert_position: string,
+     * }
+     */
+    protected array $defaultConfig = [
+        'enable' => true,
+        'ignore_part_config' => false,
+        'reaction_limit' => 20,
+        'reaction_self' => true,
+        'reaction_allows' => '',
+        'document_insert_position' => 'after',
+        'comment_insert_position' => 'after',
+    ];
+
+    /**
+     * @var array<string,string|mixed[]>
+     */
+    protected array $filter = [
+        'enable' => 'bool',
+        'ignore_part_config' => 'bool',
+        'reaction_limit' => 'int',
+        'reaction_self' => 'bool',
+        'reaction_allows' => 'string',
+        'document_insert_position' => ['before', 'after', 'disable'],
+        'comment_insert_position' => ['before', 'after', 'disable'],
+    ];
+
+    public function __construct()
+    {
+        $moduleConfig = ModuleModel::getModuleConfig($this->configKey);
+        if ($moduleConfig === null || !is_object($moduleConfig)) {
+            $moduleConfig = new \stdClass();
+        }
+
+        $this->config = (object) array_merge($this->defaultConfig, (array) $moduleConfig);
+    }
+
+    /**
+     * 모듈 활성화 여부
+     */
+    public function isEnable(): bool
+    {
+        return $this->config->enable;
+    }
+
+    /**
+     * @throws MustLogin
+     * @throws NotPermitted
+     */
+    public function reactable(SessionHelper $member): bool
+    {
+        if (!$member->isMember()) {
+            throw new MustLogin();
+        }
+
+        if ($this->getAllowGroups()) {
+            $groups = array_keys($member->getGroups());
+            if (!count(array_intersect($groups, $this->getAllowGroups()))) {
+                throw new NotPermitted();
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getAllowGroups(): array
+    {
+        $groups = explode(',', $this->config->reaction_allows);
+        $groups = array_map('intval', $groups);
+
+        return $groups;
+    }
+
+    /**
+     * @param mixed[] $vars
+     */
+    public function setVars(array $vars): void
+    {
+        $vars['reaction_allows'] = implode(',', $vars['reaction_allows'] ?? []);
+        $vars = array_merge((array) $this->config, $vars);
+
+        $this->config = (object) $this->sanitize($vars);
+    }
+
+    /**
+     * 설정 변경사항 저장
+     */
+    public function save(): \BaseObject
+    {
+        $this->config = (object) $this->sanitize(array_merge($this->defaultConfig, (array) $this->config));
+
+        $oModuleController = ModuleController::getInstance();
+        $output = $oModuleController->insertModuleConfig($this->configKey, $this->config);
+
+        return $output;
+    }
+
+    /**
+     * @param mixed[] $config
+     * @return mixed[]
+     */
+    protected function sanitize(array $config, bool $cleanup = false): array
+    {
+        return array_reduce(array_keys($config), function ($carry, $key) use ($config, $cleanup) {
+            if ($config[$key] === null) {
+                return $carry;
+            }
+
+            if (!array_key_exists($key, $this->filter)) {
+                return $carry;
+            }
+
+            $value = $config[$key];
+
+            if ($this->filter[$key] === 'string') {
+                $value = strval($value);
+            } else if ($this->filter[$key] === 'int') {
+                $value = intval($value);
+            } else if ($this->filter[$key] === 'float') {
+                $value = floatval($value);
+            } else if ($this->filter[$key] === 'array') {
+                $value = (array) $value;
+            } else if ($this->filter[$key] === 'bool') {
+                if (!is_bool($value)) {
+                    $value = in_array(
+                        strtolower(strval($value)),
+                        ['yes', 'y', 'true', 't', 'on', 'ok', 'enable', 'enabled', 'checked', 'selected', '1'],
+                        true
+                    );
+                }
+            } else if (is_array($this->filter[$key])) {
+                if (!in_array($value, $this->filter[$key], true)) {
+                    $value = $this->defaultConfig[$key];
+                }
+            }
+
+            if ($cleanup && $value === $this->defaultConfig[$key]) {
+                return $carry;
+            }
+
+            $carry[$key] = $value;
+
+            return $carry;
+        }, []);
+    }
+
+    public function gets(): object
+    {
+        return $this->config;
+    }
+
+    public function __serialize(): array
+    {
+        return (array) $this->config;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function __get(string $name)
+    {
+        return $this->config->{$name} ?? null;
+    }
+
+    /**
+     * @param ?mixed $value
+     */
+    public function __set(string $name, $value): void
+    {
+        $this->config->{$name} = $this->sanitize([$name => $value])[$name] ?? $this->defaultConfig[$name];
+    }
+}

--- a/src/models/ReactionModel.php
+++ b/src/models/ReactionModel.php
@@ -3,9 +3,13 @@ declare(strict_types=1);
 
 namespace Rhymix\Modules\Da_reaction\Src\Models;
 
+use CommentModel;
+use DocumentModel;
 use Rhymix\Framework\DB;
 use Rhymix\Framework\Exception;
+use Rhymix\Framework\Exceptions\MustLogin;
 use Rhymix\Framework\Helpers\SessionHelper;
+use Rhymix\Modules\Da_reaction\Src\Exceptions\CannotReactToOwnTargetException;
 use Rhymix\Modules\Da_reaction\Src\ModuleBase;
 use Rhymix\Modules\Da_reaction\Src\ReactionHelper;
 
@@ -184,15 +188,17 @@ class ReactionModel extends ModuleBase
      * - 추가 가능: 1 (ModuleBase::REACTABLE_ADD)
      * - 취소 가능: 2 (ModuleBase::REACTABLE_REVOKE)
      * - 추가 및 취소 가능: 3 (ModuleBase::REACTABLE)
+     *
+     * @throws CannotReactToOwnTargetException
      */
-    public static function reactable(string $targetId, string $reaction, SessionHelper $member): int
+    public static function reactable(ReactionConfig $config, SessionHelper $member, string $targetId, string $reaction): int
     {
         $reactable = ModuleBase::NOT_REACTABLE;
-        // FIXME
-        $reactionLimit = 20;
+
+        $reactionLimit = $config->reaction_limit;
 
         if (!$member->isMember()) {
-            return ModuleBase::NOT_REACTABLE;
+            throw new MustLogin();
         }
 
         $db = DB::getInstance();

--- a/src/models/ReactionPartConfig.php
+++ b/src/models/ReactionPartConfig.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+namespace Rhymix\Modules\Da_reaction\Src\Models;
+
+use ModuleController;
+use ModuleModel;
+use Rhymix\Framework\Exception;
+
+/**
+ * 리액션 모듈의 개별 인스턴스 설정
+ *
+ * @property bool $ignore_part_config
+ */
+class ReactionPartConfig extends ReactionConfig
+{
+    private int $moduleSrl;
+
+    private ReactionConfig $moduleConfig;
+
+    public function __construct(ReactionConfig $moduleConfig, int $moduleSrl)
+    {
+        $this->moduleSrl = $moduleSrl;
+        $this->moduleConfig = $moduleConfig;
+
+        $config = ModuleModel::getModulePartConfig($this->configKey, $this->moduleSrl);
+        if ($config === null || !is_object($config)) {
+            $config = new \stdClass();
+        }
+
+        $this->config = $this->moduleConfig->gets();
+        $this->config->ignore_part_config = $config->ignore_part_config;
+
+        if (!$this->config->ignore_part_config) {
+            if (!$this->config->enable) {
+                $config->enable = false;
+            }
+
+            $this->config = (object) array_merge((array) $this->config, (array) $config);
+        }
+    }
+
+    public function moduelSrl(): int
+    {
+        return $this->moduleSrl;
+    }
+
+    /**
+     * 설정 변경사항 저장
+     */
+    public function save(): \BaseObject
+    {
+        $this->config = (object) $this->sanitize((array) $this->config);
+
+        $oModuleController = ModuleController::getInstance();
+        $output = $oModuleController->insertModulePartConfig($this->configKey, $this->moduleSrl, $this->gets());
+
+        return $output;
+    }
+}

--- a/views/admin/config.blade.php
+++ b/views/admin/config.blade.php
@@ -1,0 +1,98 @@
+<?php
+/** @var \Rhymix\Modules\Da_reaction\Src\Models\ReactionConfig $daReactionConfig */
+?>
+
+@json($daReactionConfig->gets());
+
+@if($XE_VALIDATOR_MESSAGE && $XE_VALIDATOR_ID === 'da_reactioin-admin-config')
+    <div class="message {$XE_VALIDATOR_MESSAGE_TYPE}">
+        <p>{$XE_VALIDATOR_MESSAGE}</p>
+    </div>
+@endif
+
+<form action="./" method="post" class="x_form-horizontal">
+    <input type="hidden" name="module" value="admin" />
+    <input type="hidden" name="act" value="procDa_reactionAdminSaveConfig" />
+    <input type="hidden" name="xe_validator_id" value="da_reactioin-admin-config" />
+
+    <section class="section">
+        <h2>리액션 모듈 설정</h2>
+
+        <div class="x_control-group">
+            <label class="x_control-label">리액션 기능 사용</label>
+            <div class="x_controls">
+                <label class="x_inline">
+                    <input type="radio" name="enable" value="Y" @checked($daReactionConfig->enable)> 사용
+                </label>
+                <label class="x_inline">
+                    <input type="radio" name="enable" value="N" @checked(!$daReactionConfig->enable)> 모듈 비활성화
+                </label>
+            </div>
+        </div>
+
+        <div class="x_control-group">
+            <label class="x_control-label">리액션 버튼 자동 추가 - 글</label>
+            <div class="x_controls">
+                <label class="x_inline">
+                    <input type="radio" name="document_insert_position" value="before" @checked($daReactionConfig->document_insert_position === 'before') /> 위
+                </label>
+                <label class="x_inline">
+                    <input type="radio" name="document_insert_position" value="after" @checked($daReactionConfig->document_insert_position === 'after') /> 아래
+                </label>
+                <label class="x_inline">
+                    <input type="radio" name="document_insert_position" value="disable" @checked($daReactionConfig->document_insert_position === 'disable') /> 안함
+                </label>
+            </div>
+        </div>
+
+        <div class="x_control-group">
+            <label class="x_control-label">리액션 버튼 자동 추가 - 댓글</label>
+            <div class="x_controls">
+                <label class="x_inline">
+                    <input type="radio" name="comment_insert_position" value="before" @checked($daReactionConfig->comment_insert_position === 'before') /> 위
+                </label>
+                <label class="x_inline">
+                    <input type="radio" name="comment_insert_position" value="after" @checked($daReactionConfig->comment_insert_position === 'after') /> 아래
+                </label>
+                <label class="x_inline">
+                    <input type="radio" name="comment_insert_position" value="disable" @checked($daReactionConfig->comment_insert_position === 'disable') /> 안함
+                </label>
+            </div>
+        </div>
+
+        <div class="x_control-group">
+            <label class="x_control-label">리액션 제한 횟수</label>
+            <div class="x_controls">
+                <input type="number" min="1" name="reaction_limit" placeholter="20" value="{{ $daReactionConfig->reaction_limit }}" />
+            </div>
+        </div>
+
+        <div class="x_control-group">
+            <label class="x_control-label">자신의 글, 댓글에 리액션 허용</label>
+            <div class="x_controls">
+                <label><input type="radio" name="reaction_self" value="Y" @checked($daReactionConfig->reaction_self) /> 허용 - 자신의 글, 댓글에 리액션 가능</label>
+                <label><input type="radio" name="reaction_self" value="N" @checked(!$daReactionConfig->reaction_self) /> 허용하지 않음</label>
+            </div>
+        </div>
+
+        <div class="x_control-group">
+            <label class="x_control-label">리액션 허용 그룹</label>
+            <div class="x_controls">
+                @foreach ($group_list as $group)
+                    <label class="x_inline">
+                        <input type="checkbox" name="reaction_allows[]" value="{{ $group->group_srl }}" @checked(in_array($group->group_srl, $daReactionConfig->getAllowGroups()))> {{ $group->title }}
+                    </label>
+                @endforeach
+                <p class="x_help-block">그룹을 선택하지않으면 로그인 사용자에게 허용됩니다.</p>
+            </div>
+        </div>
+    </section>
+
+    <div class="x_clearfix btnArea">
+        <div class="x_pull-left">
+        </div>
+        <div class="x_pull-right">
+            <button type="submit" class="x_btn x_btn-primary">{$lang->cmd_save}</button>
+        </div>
+    </div>
+</form>

--- a/views/admin/part-config.blade.php
+++ b/views/admin/part-config.blade.php
@@ -1,0 +1,106 @@
+<?php
+/** @var \Rhymix\Modules\Da_reaction\Src\Models\ReactionPartConfig $daReactionPartConfig */
+?>
+
+<section class="section">
+    <h1>리액션 설정</h1>
+
+    <form action="./" method="post" class="x_form-horizontal">
+        <input type="hidden" name="module" value="da_reaction" />
+        <input type="hidden" name="act" value="procDa_reactionAdminSaveModuleConfig" />
+        <input type="hidden" name="success_return_url" value="{getRequestUriByServerEnviroment()}" />
+        <input type="hidden" name="target_module_srl" value="{$module_info->module_srl ?: $module_srls}" />
+
+        <div class="x_control-group">
+            <label class="x_control-label">기본 설정 사용</label>
+            <div class="x_controls">
+                <label class="x_inline">
+                    <input type="checkbox" name="ignore_part_config" value="Y" @checked($daReactionPartConfig->ignore_part_config)> 리액션 모듈의 기본 설정을 사용
+                </label>
+            </div>
+        </div>
+
+        <div class="x_control-group">
+            <label class="x_control-label">리액션 기능 사용</label>
+            <div class="x_controls">
+                <label class="x_inline">
+                    <input type="radio" name="enable" value="Y" @checked($daReactionPartConfig->enable)> 사용
+                </label>
+                <label class="x_inline">
+                    <input type="radio" name="enable" value="N" @checked(!$daReactionPartConfig->enable)> 사용 안 함
+                </label>
+            </div>
+        </div>
+
+        <div class="x_control-group">
+            <label class="x_control-label">리액션 버튼 자동 추가 - 글</label>
+            <div class="x_controls">
+                <label class="x_inline">
+                    <input type="radio" name="document_insert_position" value="before" @checked($daReactionPartConfig->document_insert_position === 'before') /> 위
+                </label>
+                <label class="x_inline">
+                    <input type="radio" name="document_insert_position" value="after" @checked($daReactionPartConfig->document_insert_position === 'after') /> 아래
+                </label>
+                <label class="x_inline">
+                    <input type="radio" name="document_insert_position" value="disable" @checked($daReactionPartConfig->document_insert_position === 'disable') /> 안함
+                </label>
+            </div>
+        </div>
+
+        <div class="x_control-group">
+            <label class="x_control-label">리액션 버튼 자동 추가 - 댓글</label>
+            <div class="x_controls">
+                <label class="x_inline">
+                    <input type="radio" name="comment_insert_position" value="before" @checked($daReactionPartConfig->comment_insert_position === 'before') /> 위
+                </label>
+                <label class="x_inline">
+                    <input type="radio" name="comment_insert_position" value="after" @checked($daReactionPartConfig->comment_insert_position === 'after') /> 아래
+                </label>
+                <label class="x_inline">
+                    <input type="radio" name="comment_insert_position" value="disable" @checked($daReactionPartConfig->comment_insert_position === 'disable') /> 안함
+                </label>
+            </div>
+        </div>
+
+        <div class="x_control-group">
+            <label class="x_control-label">리액션 제한 횟수</label>
+            <div class="x_controls">
+                <input type="number" min="1" name="reaction_limit" placeholter="20" value="{{ $daReactionPartConfig->reaction_limit }}" />
+            </div>
+        </div>
+
+        <div class="x_control-group">
+            <label class="x_control-label">자신의 글, 댓글에 리액션 허용</label>
+            <div class="x_controls">
+                <label><input type="radio" name="reaction_self" value="Y" @checked($daReactionPartConfig->reaction_self) /> 허용 - 자신의 글, 댓글에 리액션 가능</label>
+                <label><input type="radio" name="reaction_self" value="N" @checked(!$daReactionPartConfig->reaction_self) /> 허용하지 않음</label>
+            </div>
+        </div>
+
+        <div class="x_control-group">
+            <label class="x_control-label">리액션 허용 그룹</label>
+            <div class="x_controls">
+                @foreach ($group_list as $group)
+                    <label class="x_inline">
+                        <input type="checkbox" name="reaction_allows[]" value="{{ $group->group_srl }}" @checked(in_array($group->group_srl, $daReactionPartConfig->getAllowGroups()))> {{ $group->title }}
+                    </label>
+                @endforeach
+                <p class="x_help-block">그룹을 선택하지않으면 로그인 사용자에게 허용됩니다.</p>
+            </div>
+        </div>
+
+        <div class="btnArea">
+            <button class="x_btn x_btn-primary" type="submit">{$lang->cmd_save}</button>
+        </div>
+    </form>
+
+    <script>
+        jQuery(function ($) {
+            $('input[name="ignore_part_config"]').on('change', function () {
+                const $this = $(this);
+
+                $this.closest('.x_control-group').nextAll('.x_control-group').toggle(!$this.prop('checked'));
+            }).trigger('change');
+        });
+    </script>
+</section>


### PR DESCRIPTION
모듈의 설정을 추가하고 공통 설정과 게시판별 설정이 가능하도록 개선.

- 리액션 모듈의 공통 설정과 게시판별 설정 기능 추가
  - 모듈 활성화/비활성화
    - 자동 삽입 및 데이터 로드 등 전체 기능 비활성화
  - 리액션 버튼의 글, 댓글 상(before)/하(after) 삽입 또는 자동 삽입 비활성
  - 리액션 제한 횟수 : 하나의 대상에 추가할 수 있는 최대 리액션 갯수
    - 관리자는 제한이 적용되지 않음
  - 자신의 글, 댓글에 리액션 허용 여부
    - 관리자는 제한이 적용되지 않음
  - 리액션 허용 그룹
    - 비선택 시 전체 회원에게 허용
    - 그룹 선택 시 해당 그룹에 속한 회원만 허용
    - 관리자는 제한이 적용되지 않음
 

Issue #7
Fix #15